### PR TITLE
Fixed invalid file path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@ const Shift = require("shift-ast");
 const vendors = require("./vendors");
 const fs = require("fs");
 
-const filesDirectory = "files/";
-const outputDirectory = "output/";
+const filesDirectory = "../files/";
+const outputDirectory = "../output/";
 const scriptInfo = [
     {
         name: "datadome.js",


### PR DESCRIPTION
The path to `output/` and `files/` in `src/index.js` were wrongly referenced.
I changed them to their correct paths in the parent directory.
